### PR TITLE
no bug - fix paths for wsl tar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ centos6.tar.gz: Makefile
 		--name centos6 mozillabteam/centos6 > $@
 
 bundle/%/cpanfile bundle/%/cpanfile.snapshot: %.tar.gz
-	tar -zxf $< -C bundle/$* cpanfile cpanfile.snapshot
+	tar -zxf $< -C bundle/$* ./cpanfile ./cpanfile.snapshot
 	touch bundle/$*/{cpanfile,cpanfile.snapshot}
-
 


### PR DESCRIPTION
Tar under WSL cannot find cpanfile and cpanfile.snapshot unless prepended with ./ for some reason. This fixes that.